### PR TITLE
fix missing properties and libdl not found on linux

### DIFF
--- a/AssimpNet/EmbeddedTexture.cs
+++ b/AssimpNet/EmbeddedTexture.cs
@@ -63,6 +63,18 @@ namespace Assimp
             }
         }
 
+		public string OriginalFilename
+		{
+			get
+			{
+				return m_filename;
+			}
+			set
+			{
+				m_filename = value;
+			}
+		}
+
         /// <summary>
         /// Gets if the texture is compressed or not.
         /// </summary>

--- a/AssimpNet/Light.cs
+++ b/AssimpNet/Light.cs
@@ -278,6 +278,18 @@ namespace Assimp
             }
         }
 
+		public Vector2D Size
+		{
+			get
+			{
+				return m_areaSize;
+			}
+			set
+			{
+				m_areaSize = value;
+			}
+		}
+
         /// <summary>
         /// Constructs a new instance of the <see cref="Light"/> class.
         /// </summary>

--- a/AssimpNet/Unmanaged/Platforms/UnmanagedLinuxLibdlLibraryImplementation.cs
+++ b/AssimpNet/Unmanaged/Platforms/UnmanagedLinuxLibdlLibraryImplementation.cs
@@ -79,16 +79,16 @@ namespace Assimp.Unmanaged
 
         #region Native Methods
 
-        [DllImport("libdl.so")]
+        [DllImport("__Internal")]
         private static extern IntPtr dlopen(String fileName, int flags);
 
-        [DllImport("libdl.so")]
+        [DllImport("__Internal")]
         private static extern IntPtr dlsym(IntPtr handle, String functionName);
 
-        [DllImport("libdl.so")]
+        [DllImport("__Internal")]
         private static extern int dlclose(IntPtr handle);
 
-        [DllImport("libdl.so")]
+        [DllImport("__Internal")]
         private static extern IntPtr dlerror();
 
         private const int RTLD_NOW = 2;

--- a/AssimpNet/Unmanaged/UnmanagedLibrary.cs
+++ b/AssimpNet/Unmanaged/UnmanagedLibrary.cs
@@ -383,7 +383,7 @@ namespace Assimp.Unmanaged
             [DllImport("api-ms-win-core-libraryloader-l2-1-0.dll", SetLastError = true, EntryPoint = "LoadPackagedLibrary")]
             public static extern IntPtr WinUwpLoadLibrary([MarshalAs(UnmanagedType.LPWStr)] string libraryName, int reserved = 0);
 
-            [DllImport("libdl.so", EntryPoint = "dlerror")]
+            [DllImport("__Internal", EntryPoint = "dlerror")]
             public static extern IntPtr libdl_dlerror();
 
             [DllImport("libc.so.6", EntryPoint = "dlerror")]


### PR DESCRIPTION
the DllImport modifications are based on [frooxius' own commit to brotli](https://github.com/Yellow-Dog-Man/brotli.net/commit/162443d2cbbea77637ff3d210c5f681894e5c915), and everything else was figured out by s3rgal on discord, currently nicknamed "yosh" in the official resonite discord.

since assimp's shared object still does not come with linux resonite, this pull by itself will not instantly fix model importing on linux.  it _does,_ however, fix model importing on copies of linux resonite that have had assimp's shared object manually added.  or at least, it works on my linux machine.

untested on windows since i don't have it, someone else please do that.